### PR TITLE
Small cleanups

### DIFF
--- a/OSXey
+++ b/OSXey
@@ -1,4 +1,5 @@
 #!/bin/bash
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # ==USER==
 user=$(whoami)
@@ -14,7 +15,7 @@ fi
 # ==MODEL==
 model=$(system_profiler SPHardwareDataType -detailLevel mini | awk '/Model Identifier/ { print $3 }')
 # use grep to find the model in the list, then delete from ) to end of line
-modelname=`grep $model Models.txt | sed -e 's/).*/)/g'`
+modelname=`grep $model $DIR/Models.txt | sed -e 's/).*/)/g'`
 
 # ==VERSION==
 versionNumber=$(sw_vers -productVersion) # Finds version number
@@ -73,7 +74,7 @@ terminal="$TERM"
 # check if brew or macports is installed, then total there packages and set packagehandler 
 if [ -e /usr/local/bin/brew ]
 then
-	brewpackages=$(brew list -l | tail -n +2 | wc -l)
+	brewpackages=$(brew list -l | tail -n +2 | wc -l | tr -d ' ')
 	packagehandler=$brewpackages
 elif [ -f /opt/local/bin/port ] #don't think this is the right directory, need to check later.
 then 


### PR DESCRIPTION
When not run from the directory where Models.txt was installed the file would not be found and an error would be given.

Also, I trimmed the leading whitespace from the brew package count.