### PR TITLE
remove new line in resolution output with 2 monitors

### DIFF
--- a/OSXey
+++ b/OSXey
@@ -17,6 +17,9 @@ normal=$(tput sgr0)
 while [ $# -gt 0 ]
 do
 	case "$1" in
+
+    -c|--color)
+			GR='\033[00;32m'
 			YE='\033[00;33m'
 			LR='\033[01;31m'
 			RE='\033[00;31m'

--- a/OSXey
+++ b/OSXey
@@ -17,9 +17,6 @@ normal=$(tput sgr0)
 while [ $# -gt 0 ]
 do
 	case "$1" in
-
-    -c|--color)
-			GR='\033[00;32m'
 			YE='\033[00;33m'
 			LR='\033[01;31m'
 			RE='\033[00;31m'
@@ -81,7 +78,7 @@ awk '/Model/{for (i=1; i<=NF-2; i++) $i = $(i+2); NF-=2; print}' | paste -sd "/"
 graphicsnoBrand=$(system_profiler SPDisplaysDataType |
 awk '/Model/{for (i=1; i<=NF-3; i++) $i = $(i+3); NF-=3; print}' | paste -sd "/" -)
 
-resolution=$(system_profiler SPDisplaysDataType | grep Resolution | cut -d':' -f2 | sed -e 's/^[ \t]*//')
+resolution=$(system_profiler SPDisplaysDataType | grep Resolution | cut -d':' -f2 | sed -e 's/^[ \t]*//' | awk '$1=$1' ORS=' ')
 
 # Use system_profiler to find graphics cards, then awk to find 'Model'
 # Output of this step is lines such as this:


### PR DESCRIPTION
if you had 2 monitors, it would print both resolutions on 2 lines breaking the apple logo, now puts all resolutions on one line.
