### PR TITLE
Add MacBook Models + Change Model Find

### DIFF
--- a/Models.txt
+++ b/Models.txt
@@ -25,81 +25,81 @@ MacBook (13-inch, Early 2006)                   MacBook1,1
 
 ### MacBook Pro 13-inch
 
-MacBook Pro (Retina, 13-inch, Early 2015)           MacBookPro12,1
+MacBook Pro (Retina, 13-inch, Early 2015)   MacBookPro12,1
 MacBook Pro (Retina, 13-inch, Mid 2014/Late 2013)	MacBookPro11,1
 MacBook Pro (Retina, 13-inch, Early 2013/Late 2012)	MacBookPro10,2
-MacBook Pro (13-inch, Mid 2012)	                    MacBookPro9,2
+MacBook Pro (13-inch, Mid 2012)	            MacBookPro9,2
 MacBook Pro (13-inch, Late 2011/Early 2011)	        MacBookPro8,1
-MacBook Pro (13-inch, Mid 2010)	                    MacBookPro7,1
-MacBook Pro (13-inch, Mid 2009)          	        MacBookPro5,5
+MacBook Pro (13-inch, Mid 2010)	            MacBookPro7,1
+MacBook Pro (13-inch, Mid 2009)          	MacBookPro5,5
 
 ### MacBook Pro 15-inch
 
 # Spaces? Appears in the document. Have to test on real machine
-MacBook Pro (Retina, 15-inch, Mid 2014/Late 2013)   MacBookPro11,2 || MacBookPro11,3
+MacBook Pro (Retina, 15-inch, Mid 2014/Late 2013) MacBookPro11,2 || MacBookPro11,3
 MacBook Pro (Retina, 15-inch, Mid 2012/Early 2013)	MacBookPro10,1	
-MacBook Pro (15-inch, Mid 2012)	                    MacBookPro9,1
-MacBook Pro (15-inch, Late 2011/Early 2011)	        MacBookPro8,2
-MacBook Pro (15-inch, Mid 2010)	                    MacBookPro6,2
-MacBook Pro (15-inch, Mid 2009)	                    MacBookPro5,3
-MacBook Pro (15-inch, Late 2008)	                MacBookPro5,1
-MacBook Pro (15-inch, Early 2008)	                MacBookPro4,1
-MacBook Pro (15-inch, 2.4/2.2 GHz)	                MacBookPro3,1
-MacBook Pro (15-inch, Core 2 Duo)	                MacBookPro2,2
-MacBook Pro (15-inch, Glossy)	                    MacBookPro1,1
+MacBook Pro (15-inch, Mid 2012)	MacBookPro9,1
+MacBook Pro (15-inch, Late 2011/Early 2011)	MacBookPro8,2
+MacBook Pro (15-inch, Mid 2010)	MacBookPro6,2
+MacBook Pro (15-inch, Mid 2009)	MacBookPro5,3
+MacBook Pro (15-inch, Late 2008)	MacBookPro5,1
+MacBook Pro (15-inch, Early 2008)	MacBookPro4,1
+MacBook Pro (15-inch, 2.4/2.2 GHz)	MacBookPro3,1
+MacBook Pro (15-inch, Core 2 Duo)	MacBookPro2,2
+MacBook Pro (15-inch, Glossy)	MacBookPro1,1
 
 ### MacBook Pro (17-inch)
 
-MacBook Pro (17-inch, Late 2011/Early 2011)	    MacBookPro8,3
-MacBook Pro (17-inch, Mid 2010)	                MacBookPro6,1
-MacBook Pro (17-inch, Mid 2009/Early 2009)	    MacBookPro5,2
-MacBook Pro (17-inch, Late 2008)	            MacBookPro5,1
-MacBook Pro (17-inch, Early 2008)	            MacBookPro4,1
-MacBook Pro (17-inch, 2.4 GHz, Late 2007)	    MacBookPro3,1
-MacBook Pro (17-inch, Core 2 Duo)	            MacBookPro2,1
-MacBook Pro (17-inch)	                        MacBookPro1,2
+MacBook Pro (17-inch, Late 2011/Early 2011)	MacBookPro8,3
+MacBook Pro (17-inch, Mid 2010)	MacBookPro6,1
+MacBook Pro (17-inch, Mid 2009/Early 2009)	MacBookPro5,2
+MacBook Pro (17-inch, Late 2008)	MacBookPro5,1
+MacBook Pro (17-inch, Early 2008)	MacBookPro4,1
+MacBook Pro (17-inch, 2.4 GHz, Late 2007)	MacBookPro3,1
+MacBook Pro (17-inch, Core 2 Duo)	MacBookPro2,1
+MacBook Pro (17-inch)	MacBookPro1,2
 
 
 
 # How to identify MacBook Air models
 # Taken from http://support.apple.com/kb/ht3255
 
-MacBook Air (13-inch, Early 2015)           MacBookAir7,2
-MacBook Air (11-inch, Early 2015)           MacBookAir7,1
+MacBook Air (13-inch, Early 2015)   MacBookAir7,2
+MacBook Air (11-inch, Early 2015)   MacBookAir7,1
 MacBook Air (13-inch, Early 2014/Mid 2013)	MacBookAir6,2
 MacBook Air (11-inch, Early 2014/Mid 2013)	MacBookAir6,1
-MacBook Air (13-inch, Mid 2012)	            MacBookAir5,2
-MacBook Air (11-inch, Mid 2012)	            MacBookAir5,1
-MacBook Air (13-inch, Mid 2011)	            MacBookAir4,2
-MacBook Air (11-inch, Mid 2011)	            MacBookAir4,1
-MacBook Air (13-inch, Late 2010)	        MacBookAir3,2
-MacBook Air (11-inch, Late 2010)	        MacBookAir3,1
+MacBook Air (13-inch, Mid 2012)	MacBookAir5,2
+MacBook Air (11-inch, Mid 2012)	MacBookAir5,1
+MacBook Air (13-inch, Mid 2011)	MacBookAir4,2
+MacBook Air (11-inch, Mid 2011)	MacBookAir4,1
+MacBook Air (13-inch, Late 2010)	MacBookAir3,2
+MacBook Air (11-inch, Late 2010)	MacBookAir3,1
 MacBook Air (13-inch, Mid 2009/Late 2008)	MacBookAir2,1
-MacBook Air (13-inch, Early 2008)	        MacBookAir1,1
+MacBook Air (13-inch, Early 2008)	MacBookAir1,1
 
 
 
 # How to identify iMac models
 # Taken from http://support.apple.com/kb/ht1758
-iMac (Retina, 27-inch, Late 2014)       iMac15,1    MF886XX/A
-iMac (21.5-inch, Mid 2014)              iMac14,4    MF883LL/A
-iMac (21.5-inch, Late 2013)	            iMac14,1	ME086XX/A
-iMac (27-inch, Late 2013)	            iMac14,2	ME088XX/A
-iMac (21.5-inch, Late 2012)	            iMac13,1	MD093XX/A
-iMac (27-inch, Late 2012)	            iMac13,2	MD096XX/A
-iMac (21.5-inch, Mid 2011)	            iMac12,1	MC812XX/A
-iMac (27-inch, Mid 2011)	            iMac12,2	MC814XX/A
-iMac (21.5-inch, Mid 2010)	            iMac11,2	MC509XX/A
-iMac (27-inch, Mid 2010)	            iMac11,3	MC511XX/A
-iMac (21.5-inch/27-inch, Late 2009)	    iMac10,1	MC413XX/A
-iMac (27-inch, Late 2009)	            iMac11,1	MB953XX/A
-iMac (20-inch/24-inch, Early 2009)	    iMac9,1	    MB417XX/A
-iMac (20-inch/24-inch, Early 2008)	    iMac8,1	    MB323XX/A
-iMac (20-inch/24-inch, Mid 2007)	    iMac7,1	    MA876XX/A
-iMac (17-inch/20-inch, Late 2006)	    iMac5,1	    MA589xx/A
-iMac (17-inch Late 2006 CD)	            iMac5,2	    MA710xx/A
-iMac (17-inch, Mid 2006)	            iMac4,2	    MA406xx/A
-iMac (17-inch/20-inch, Early 2006)	    iMac4,1	    MA200xx/A
+iMac (Retina, 27-inch, Late 2014)   iMac15,1   MF886XX/A
+iMac (21.5-inch, Mid 2014)   iMac14,4   MF883LL/A
+iMac (21.5-inch, Late 2013)	 iMac14,1	ME086XX/A
+iMac (27-inch, Late 2013)	 iMac14,2	ME088XX/A
+iMac (21.5-inch, Late 2012)	 iMac13,1	MD093XX/A
+iMac (27-inch, Late 2012)	 iMac13,2	MD096XX/A
+iMac (21.5-inch, Mid 2011)	 iMac12,1	MC812XX/A
+iMac (27-inch, Mid 2011)	 iMac12,2	MC814XX/A
+iMac (21.5-inch, Mid 2010)	 iMac11,2	MC509XX/A
+iMac (27-inch, Mid 2010)	 iMac11,3	MC511XX/A
+iMac (21.5-inch/27-inch, Late 2009)	iMac10,1	MC413XX/A
+iMac (27-inch, Late 2009)	iMac11,1	MB953XX/A
+iMac (20-inch/24-inch, Early 2009)	iMac9,1	MB417XX/A
+iMac (20-inch/24-inch, Early 2008)	 iMac8,1	MB323XX/A
+iMac (20-inch/24-inch, Mid 2007)	iMac7,1	MA876XX/A
+iMac (17-inch/20-inch, Late 2006)	iMac5,1	MA589xx/A
+iMac (17-inch Late 2006 CD)	iMac5,2	MA710xx/A
+iMac (17-inch, Mid 2006)	iMac4,2	MA406xx/A
+iMac (17-inch/20-inch, Early 2006)	iMac4,1	MA200xx/A
 
 # How to identify Mac Pro models
 # Taken from http://support.apple.com/kb/HT6069

--- a/Models.txt
+++ b/Models.txt
@@ -25,81 +25,81 @@ MacBook (13-inch, Early 2006)                   MacBook1,1
 
 ### MacBook Pro 13-inch
 
-MacBook Pro (Retina, 13-inch, Early 2015)   MacBookPro12,1
+MacBook Pro (Retina, 13-inch, Early 2015)           MacBookPro12,1
 MacBook Pro (Retina, 13-inch, Mid 2014/Late 2013)	MacBookPro11,1
 MacBook Pro (Retina, 13-inch, Early 2013/Late 2012)	MacBookPro10,2
-MacBook Pro (13-inch, Mid 2012)	            MacBookPro9,2
+MacBook Pro (13-inch, Mid 2012)	                    MacBookPro9,2
 MacBook Pro (13-inch, Late 2011/Early 2011)	        MacBookPro8,1
-MacBook Pro (13-inch, Mid 2010)	            MacBookPro7,1
-MacBook Pro (13-inch, Mid 2009)          	MacBookPro5,5
+MacBook Pro (13-inch, Mid 2010)	                    MacBookPro7,1
+MacBook Pro (13-inch, Mid 2009)          	        MacBookPro5,5
 
 ### MacBook Pro 15-inch
 
 # Spaces? Appears in the document. Have to test on real machine
-MacBook Pro (Retina, 15-inch, Mid 2014/Late 2013) MacBookPro11,2 || MacBookPro11,3
+MacBook Pro (Retina, 15-inch, Mid 2014/Late 2013)   MacBookPro11,2 || MacBookPro11,3
 MacBook Pro (Retina, 15-inch, Mid 2012/Early 2013)	MacBookPro10,1	
-MacBook Pro (15-inch, Mid 2012)	MacBookPro9,1
-MacBook Pro (15-inch, Late 2011/Early 2011)	MacBookPro8,2
-MacBook Pro (15-inch, Mid 2010)	MacBookPro6,2
-MacBook Pro (15-inch, Mid 2009)	MacBookPro5,3
-MacBook Pro (15-inch, Late 2008)	MacBookPro5,1
-MacBook Pro (15-inch, Early 2008)	MacBookPro4,1
-MacBook Pro (15-inch, 2.4/2.2 GHz)	MacBookPro3,1
-MacBook Pro (15-inch, Core 2 Duo)	MacBookPro2,2
-MacBook Pro (15-inch, Glossy)	MacBookPro1,1
+MacBook Pro (15-inch, Mid 2012)	                    MacBookPro9,1
+MacBook Pro (15-inch, Late 2011/Early 2011)	        MacBookPro8,2
+MacBook Pro (15-inch, Mid 2010)	                    MacBookPro6,2
+MacBook Pro (15-inch, Mid 2009)	                    MacBookPro5,3
+MacBook Pro (15-inch, Late 2008)	                MacBookPro5,1
+MacBook Pro (15-inch, Early 2008)	                MacBookPro4,1
+MacBook Pro (15-inch, 2.4/2.2 GHz)	                MacBookPro3,1
+MacBook Pro (15-inch, Core 2 Duo)	                MacBookPro2,2
+MacBook Pro (15-inch, Glossy)	                    MacBookPro1,1
 
 ### MacBook Pro (17-inch)
 
-MacBook Pro (17-inch, Late 2011/Early 2011)	MacBookPro8,3
-MacBook Pro (17-inch, Mid 2010)	MacBookPro6,1
-MacBook Pro (17-inch, Mid 2009/Early 2009)	MacBookPro5,2
-MacBook Pro (17-inch, Late 2008)	MacBookPro5,1
-MacBook Pro (17-inch, Early 2008)	MacBookPro4,1
-MacBook Pro (17-inch, 2.4 GHz, Late 2007)	MacBookPro3,1
-MacBook Pro (17-inch, Core 2 Duo)	MacBookPro2,1
-MacBook Pro (17-inch)	MacBookPro1,2
+MacBook Pro (17-inch, Late 2011/Early 2011)	    MacBookPro8,3
+MacBook Pro (17-inch, Mid 2010)	                MacBookPro6,1
+MacBook Pro (17-inch, Mid 2009/Early 2009)	    MacBookPro5,2
+MacBook Pro (17-inch, Late 2008)	            MacBookPro5,1
+MacBook Pro (17-inch, Early 2008)	            MacBookPro4,1
+MacBook Pro (17-inch, 2.4 GHz, Late 2007)	    MacBookPro3,1
+MacBook Pro (17-inch, Core 2 Duo)	            MacBookPro2,1
+MacBook Pro (17-inch)	                        MacBookPro1,2
 
 
 
 # How to identify MacBook Air models
 # Taken from http://support.apple.com/kb/ht3255
 
-MacBook Air (13-inch, Early 2015)   MacBookAir7,2
-MacBook Air (11-inch, Early 2015)   MacBookAir7,1
+MacBook Air (13-inch, Early 2015)           MacBookAir7,2
+MacBook Air (11-inch, Early 2015)           MacBookAir7,1
 MacBook Air (13-inch, Early 2014/Mid 2013)	MacBookAir6,2
 MacBook Air (11-inch, Early 2014/Mid 2013)	MacBookAir6,1
-MacBook Air (13-inch, Mid 2012)	MacBookAir5,2
-MacBook Air (11-inch, Mid 2012)	MacBookAir5,1
-MacBook Air (13-inch, Mid 2011)	MacBookAir4,2
-MacBook Air (11-inch, Mid 2011)	MacBookAir4,1
-MacBook Air (13-inch, Late 2010)	MacBookAir3,2
-MacBook Air (11-inch, Late 2010)	MacBookAir3,1
+MacBook Air (13-inch, Mid 2012)	            MacBookAir5,2
+MacBook Air (11-inch, Mid 2012)	            MacBookAir5,1
+MacBook Air (13-inch, Mid 2011)	            MacBookAir4,2
+MacBook Air (11-inch, Mid 2011)	            MacBookAir4,1
+MacBook Air (13-inch, Late 2010)	        MacBookAir3,2
+MacBook Air (11-inch, Late 2010)	        MacBookAir3,1
 MacBook Air (13-inch, Mid 2009/Late 2008)	MacBookAir2,1
-MacBook Air (13-inch, Early 2008)	MacBookAir1,1
+MacBook Air (13-inch, Early 2008)	        MacBookAir1,1
 
 
 
 # How to identify iMac models
 # Taken from http://support.apple.com/kb/ht1758
-iMac (Retina, 27-inch, Late 2014)   iMac15,1   MF886XX/A
-iMac (21.5-inch, Mid 2014)   iMac14,4   MF883LL/A
-iMac (21.5-inch, Late 2013)	 iMac14,1	ME086XX/A
-iMac (27-inch, Late 2013)	 iMac14,2	ME088XX/A
-iMac (21.5-inch, Late 2012)	 iMac13,1	MD093XX/A
-iMac (27-inch, Late 2012)	 iMac13,2	MD096XX/A
-iMac (21.5-inch, Mid 2011)	 iMac12,1	MC812XX/A
-iMac (27-inch, Mid 2011)	 iMac12,2	MC814XX/A
-iMac (21.5-inch, Mid 2010)	 iMac11,2	MC509XX/A
-iMac (27-inch, Mid 2010)	 iMac11,3	MC511XX/A
-iMac (21.5-inch/27-inch, Late 2009)	iMac10,1	MC413XX/A
-iMac (27-inch, Late 2009)	iMac11,1	MB953XX/A
-iMac (20-inch/24-inch, Early 2009)	iMac9,1	MB417XX/A
-iMac (20-inch/24-inch, Early 2008)	 iMac8,1	MB323XX/A
-iMac (20-inch/24-inch, Mid 2007)	iMac7,1	MA876XX/A
-iMac (17-inch/20-inch, Late 2006)	iMac5,1	MA589xx/A
-iMac (17-inch Late 2006 CD)	iMac5,2	MA710xx/A
-iMac (17-inch, Mid 2006)	iMac4,2	MA406xx/A
-iMac (17-inch/20-inch, Early 2006)	iMac4,1	MA200xx/A
+iMac (Retina, 27-inch, Late 2014)       iMac15,1    MF886XX/A
+iMac (21.5-inch, Mid 2014)              iMac14,4    MF883LL/A
+iMac (21.5-inch, Late 2013)	            iMac14,1	ME086XX/A
+iMac (27-inch, Late 2013)	            iMac14,2	ME088XX/A
+iMac (21.5-inch, Late 2012)	            iMac13,1	MD093XX/A
+iMac (27-inch, Late 2012)	            iMac13,2	MD096XX/A
+iMac (21.5-inch, Mid 2011)	            iMac12,1	MC812XX/A
+iMac (27-inch, Mid 2011)	            iMac12,2	MC814XX/A
+iMac (21.5-inch, Mid 2010)	            iMac11,2	MC509XX/A
+iMac (27-inch, Mid 2010)	            iMac11,3	MC511XX/A
+iMac (21.5-inch/27-inch, Late 2009)	    iMac10,1	MC413XX/A
+iMac (27-inch, Late 2009)	            iMac11,1	MB953XX/A
+iMac (20-inch/24-inch, Early 2009)	    iMac9,1	    MB417XX/A
+iMac (20-inch/24-inch, Early 2008)	    iMac8,1	    MB323XX/A
+iMac (20-inch/24-inch, Mid 2007)	    iMac7,1	    MA876XX/A
+iMac (17-inch/20-inch, Late 2006)	    iMac5,1	    MA589xx/A
+iMac (17-inch Late 2006 CD)	            iMac5,2	    MA710xx/A
+iMac (17-inch, Mid 2006)	            iMac4,2	    MA406xx/A
+iMac (17-inch/20-inch, Early 2006)	    iMac4,1	    MA200xx/A
 
 # How to identify Mac Pro models
 # Taken from http://support.apple.com/kb/HT6069

--- a/Models.txt
+++ b/Models.txt
@@ -10,6 +10,19 @@
 # How to identify MacBook Pro models
 # Taken from http://support.apple.com/kb/ht4132
 
+### MacBook
+
+MacBook (12-inch, Early 2015)                   MacBook8,1
+MacBook (13-inch, White, Mid 2010)              MacBook7,1
+MacBook (13-inch, White, Late 2009)             MacBook6,1
+MacBook (13-inch, White, Mid 2009/Early 2009)   MacBook5,2
+MacBook (13-inch, Aluminum, Late 2008)          MacBook5,1
+MacBook (13-inch, White, Late 2008)             MacBook4,2
+MacBook (13-inch, Early 2008)                   MacBook4,1
+MacBook (13-inch, Late 2007)                    MacBook3,1
+MacBook (13-inch, Mid 2007/Late 2006)           MacBook2,1
+MacBook (13-inch, Early 2006)                   MacBook1,1
+
 ### MacBook Pro 13-inch
 
 MacBook Pro (Retina, 13-inch, Early 2015)   MacBookPro12,1

--- a/OSXey
+++ b/OSXey
@@ -70,7 +70,7 @@ then
 fi
 
 # ==MODEL==
-model=$(system_profiler SPHardwareDataType -detailLevel mini | awk '/Model Identifier/ { print $3 }')
+model=$(sysctl hw.model | awk '/hw.model/ { print $2 }')
 # use grep to find the model in the list, then delete from ) to end of line
 modelname=`grep $model $DIR/Models.txt | sed -e 's/).*/)/g'`
 


### PR DESCRIPTION
So I came across a strange bug in recent OSX installs - when you use system_profiler it will spit out errors, which pop up every time you run osxey.
```
opsek:~ snip$ system_profiler SPHardwareDataType
2015-04-27 09:45:45.153 system_profiler[856:18996] platformPluginDictionary: Can't get X86PlatformPlugin, return value 0
2015-04-27 09:45:45.156 system_profiler[856:18996] platformPluginDictionary: Can't get X86PlatformPlugin, return value 0
Hardware:
```
I've noticed it only happens in installs that are done by using Apple recovery - I bought a brand new 2015 13" MBP and didn't have the issue, nor does my 27" iMac have the issue.  I reformatted an older 2010 MacBook a few times before I figured out the issue.

Anyway, long story short, new method to find model identifier.